### PR TITLE
auto-mounting degraded multi-device root partitions

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -17,6 +17,6 @@ package() {
     install -o root -g root -D ${srcdir}/btrfs_config  ${pkgdir}/etc/default/btrfs_advanced
 }
 
-md5sums=('0b28de2e0ba9ce54c8fa4956fd051978'
+md5sums=('41764e1263f19fe573f0c51d0f67f882'
          '8198a307fe8a38195016e7265833473c'
          '15ba7c02542cccba2c1c0c1d7f343a9f')

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,5 +1,5 @@
 # Contributor: C Anthony Risinger
-# Contributor: Michael Göhler
+# Contributor: Michael Goehler
 pkgname='mkinitcpio-btrfs'
 pkgver=0.4.1
 pkgrel=1
@@ -17,6 +17,6 @@ package() {
     install -o root -g root -D ${srcdir}/btrfs_config  ${pkgdir}/etc/default/btrfs_advanced
 }
 
-md5sums=('a0d0b89578ca8bf36d9fe96b21208252'
+md5sums=('1b7cabe4393e24c15b4e93dea6d483d8'
          '8198a307fe8a38195016e7265833473c'
-         '7b5c896000e2d6337f45555eb593a046')
+         'aef37ebd18ae5c83b3e55056b666870b')

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,9 +1,9 @@
 # Contributor: C Anthony Risinger
 # Contributor: Michael Göhler
 pkgname='mkinitcpio-btrfs'
-pkgver=0.4.0
-pkgrel=2
-pkgdesc='[initramfs] Rollback operations on BTRFS-based root devices'
+pkgver=0.4.1
+pkgrel=1
+pkgdesc='mkinitcpio hook containing advanced features for btrfs-based root devices'
 url='https://github.com/xtfxme/mkinitcpio-btrfs'
 arch=('any')
 license=('BSD')
@@ -17,6 +17,6 @@ package() {
     install -o root -g root -D ${srcdir}/btrfs_config  ${pkgdir}/etc/default/btrfs_advanced
 }
 
-md5sums=('acdbaa277e58ffbc86332736997bafb2'
+md5sums=('0b28de2e0ba9ce54c8fa4956fd051978'
          '8198a307fe8a38195016e7265833473c'
-         'dc9e745e44e9c9c3c4a2de5aa48ce3e1')
+         '15ba7c02542cccba2c1c0c1d7f343a9f')

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -17,6 +17,6 @@ package() {
     install -o root -g root -D ${srcdir}/btrfs_config  ${pkgdir}/etc/default/btrfs_advanced
 }
 
-md5sums=('41764e1263f19fe573f0c51d0f67f882'
+md5sums=('edd426a36afd198e2db52a0ff5fe87ad'
          '8198a307fe8a38195016e7265833473c'
-         '15ba7c02542cccba2c1c0c1d7f343a9f')
+         '7b5c896000e2d6337f45555eb593a046')

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -17,6 +17,6 @@ package() {
     install -o root -g root -D ${srcdir}/btrfs_config  ${pkgdir}/etc/default/btrfs_advanced
 }
 
-md5sums=('edd426a36afd198e2db52a0ff5fe87ad'
+md5sums=('c835de325963d79ee283911a6b49cfc0'
          '8198a307fe8a38195016e7265833473c'
          '7b5c896000e2d6337f45555eb593a046')

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -17,6 +17,6 @@ package() {
     install -o root -g root -D ${srcdir}/btrfs_config  ${pkgdir}/etc/default/btrfs_advanced
 }
 
-md5sums=('1b7cabe4393e24c15b4e93dea6d483d8'
+md5sums=('3c8e8b5b48f1e92c84178c63f1a2655f'
          '8198a307fe8a38195016e7265833473c'
          'aef37ebd18ae5c83b3e55056b666870b')

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -17,6 +17,6 @@ package() {
     install -o root -g root -D ${srcdir}/btrfs_config  ${pkgdir}/etc/default/btrfs_advanced
 }
 
-md5sums=('c835de325963d79ee283911a6b49cfc0'
+md5sums=('a0d0b89578ca8bf36d9fe96b21208252'
          '8198a307fe8a38195016e7265833473c'
          '7b5c896000e2d6337f45555eb593a046')

--- a/README.md
+++ b/README.md
@@ -79,12 +79,24 @@ Before doing that, install mkinitcpio-btrfs.
     $ cd /root/mkinitcpio-btrfs
     $ makepkg -i --asroot
 
-Add btrfs_advanced to your HOOKS variable, Modify /etc/default/btrfs_advanced
-if needed, and generate your initial RAM disk.
+Add btrfs_advanced to your HOOKS variable.
+
+    $ vi /etc/mkinitcpio.conf
+
+Modify /etc/default/btrfs_advanced to your needs.
+
+    $ vi /etc/default/btrfs_advanced
+
+Generate your initial RAM disk.
+
+    $ mkinitcpio -p linux
 
 Install your bootloader and reboot.
 
-### Hints:
+Note: In multi device RAID setups, install your bootloader to multible
+drives too.
+
+### Usage Hints:
 
 Create a snapshot of your root filesystem.
 
@@ -96,7 +108,7 @@ Use "btrfs scrub" for periodic online filesystem checks.
     $ sudo btrfs scrub start /
     $ sudo btrfs scrub status /
 
-If you use a multi device RAID setup, make sure you rebalance after system upgrades, to prevent kernel panic on device failure.
+If you use a multi device RAID setup, make sure you rebalance after system
+upgrades, to prevent kernel panic on device failure.
 
     $ sudo btrfs balance /
-

--- a/btrfs_config
+++ b/btrfs_config
@@ -12,7 +12,16 @@ BTRFS_DIR_SNAPSHOT="/__snapshot"
 # triggered. To make it permanent create a snapshot to BTRFS_DIR_ACTIVE.
 BTRFS_DIR_ROLLBACK="/__rollback"
 
-# If you use a custom kernel, specify its location below.
+# Define if we have to do kernel rollbacks (enabled by default).
+#
+# In setup with a separate /boot partiton this must be enabled to prevent
+# this hook from searching for the kernel on your btrfs root.
+#BTRFS_ROLLBACK_KERNEL=false
+
+# If you use a custom kernel, specify its name and location below.
+#
+# Currently the kernel must be part on your root volume, as we don't mount
+# anything else in early boot stage.
 #BTRFS_KERNEL="/boot/vmlinuz-linux"
 #BTRFS_INITRD="/boot/initramfs-linux.img"
 

--- a/btrfs_config
+++ b/btrfs_config
@@ -25,6 +25,11 @@ BTRFS_DIR_ROLLBACK="/__rollback"
 #BTRFS_KERNEL="/boot/vmlinuz-linux"
 #BTRFS_INITRD="/boot/initramfs-linux.img"
 
+# EXPERIMENTAL: By default we reload the kernel always. Even if we do not
+# rollback. But you can enable this feature if you want the kernel to be
+# reloaded on version change only. It detects build number/date changes too.
+#BTRFS_KVER_CHECK=true
+
 # EXPERIMENTAL: Try to mount RAID setups, when there are devices missing.
 #
 # This is usualy wanted on productive setups, because btrfs supports to

--- a/btrfs_config
+++ b/btrfs_config
@@ -1,15 +1,29 @@
-# This file contains some information for the btrfs_advanced initcpio hook
+# This file contains some information for the btrfs_advanced initcpio hook.
 
-# Define the default subvolume for our root filesystem
+# Define the default subvolume for our root filesystem.
 BTRFS_DIR_ACTIVE="/__active"
 
-# Define the folder containing snapshots of our root filesystem
+# Define the folder containing snapshots of our root filesystem.
 BTRFS_DIR_SNAPSHOT="/__snapshot"
 
-# Define the subvolume used for rollback operations
+# Define the subvolume used for rollback operations.
 #
 # This subvolume is temporary and gets deleted each time a restore is
 # triggered. To make it permanent create a snapshot to BTRFS_DIR_ACTIVE.
 BTRFS_DIR_ROLLBACK="/__rollback"
+
+# If you use a custom kernel, specify its location below.
+#BTRFS_KERNEL="/boot/vmlinuz-linux"
+#BTRFS_INITRD="/boot/initramfs-linux.img"
+
+# EXPERIMENTAL: Try to mount RAID setups, when there are devices missing.
+#
+# This is usualy wanted on productive setups, because btrfs supports to
+# replace faulty drives online.
+#
+# ATTENTION: If you enable this, you need to make sure to rebalance the btrfs
+# RAID after system upgrade. Otherwise kernal panic is possible by unbalanced
+# libraries.
+#BTRFS_ENABLE_DEGRADED=true
 
 # vim:set syntax=sh:

--- a/btrfs_hook
+++ b/btrfs_hook
@@ -68,7 +68,7 @@ btrfs_mount_handler () {
     BTRFS_DIR_WORK=${work}
 
     # scan for multi device filesystems
-    btrfs device scan $device 2>&1 | grep -v "No medium found"
+    btrfs device scan 2>&1 | grep -v "No medium found"
 
     # temporary mount btrfs root subvolume
     if ! mount -t btrfs -o subvolid=0,rw ${root} ${work}; then

--- a/btrfs_hook
+++ b/btrfs_hook
@@ -178,8 +178,8 @@ btrfs_mount_handler () {
                 # at this point the kernel reloads the initramfs and
                 # restarts init - no further code is executed
             else
-                btrfs_warn "Unable to load new kernel from root subvolume"
-                btrfs_warn "Check your configuration in /etc/default/btrfs_advanced"
+                btrfs_warn "Unable to load kernel from new root subvolume"
+                btrfs_warn "Check your config in /etc/default/btrfs_advanced"
             fi
 
             # unmount btrfs root subvolume

--- a/btrfs_hook
+++ b/btrfs_hook
@@ -58,6 +58,7 @@ BTRFS_DIR_ROLLBACK="${BTRFS_DIR_ROLLBACK%/}"
 : ${BTRFS_ROLLBACK_CHOICE:="default"}
 : ${BTRFS_ROLLBACK_LIST:="default"}
 : ${BTRFS_ROLLBACK_LIST_COUNT:=1}
+: ${BTRFS_ROLLBACK_KERNEL:=true}
 : ${BTRFS_KERNEL:="/boot/vmlinuz-linux"}
 : ${BTRFS_INITRD:="/boot/initramfs-linux.img"}
 : ${BTRFS_ENABLE_DEGRADED:=false}
@@ -154,19 +155,27 @@ btrfs_mount_handler () {
         btrfs_info "Booting from subvolume [${BTRFS_BOOT_SUBVOL}]..."
         btrfs subvolume set-default ${BTRFS_BOOT_SUBVOLID} ${work}
 
-        # copy kernel to initramfs
-        cp "${work}${BTRFS_BOOT_SUBVOL}${BTRFS_KERNEL}" "/tmp/linux"
-        cp "${work}${BTRFS_BOOT_SUBVOL}${BTRFS_INITRD}" "/tmp/initrd"
+        if ${BTRFS_ROLLBACK_KERNEL}; then
+            # copy kernel to initramfs
+            cp "${work}${BTRFS_BOOT_SUBVOL}${BTRFS_KERNEL}" "/tmp/linux"
+            cp "${work}${BTRFS_BOOT_SUBVOL}${BTRFS_INITRD}" "/tmp/initrd"
 
-        # unmount btrfs root subvolume
-        ! umount ${BTRFS_DIR_WORK} &&
-            btrfs_fatal "Unable to umount root subvolume" &&
-            return 1
-        BTRFS_IS_MOUNTED=false
+            # unmount btrfs root subvolume
+            ! umount ${BTRFS_DIR_WORK} &&
+                btrfs_fatal "Unable to umount root subvolume" &&
+                return 1
+            BTRFS_IS_MOUNTED=false
 
-        # force reload kernel
-        btrfs_info "Reloading kernel from [${BTRFS_BOOT_SUBVOL}]..."
-        kexec -f "/tmp/linux" --initrd="/tmp/initrd" --reuse-cmdline --append="kexeced=true"
+            # force reload kernel
+            btrfs_info "Reloading kernel from [${BTRFS_BOOT_SUBVOL}]..."
+            kexec -f "/tmp/linux" --initrd="/tmp/initrd" --reuse-cmdline --append="kexeced=true"
+        else
+            # unmount btrfs root subvolume
+            ! umount ${BTRFS_DIR_WORK} &&
+                btrfs_fatal "Unable to umount root subvolume" &&
+                return 1
+            BTRFS_IS_MOUNTED=false
+        fi
     fi
 
     btrfs_process_mount ${work}

--- a/btrfs_hook
+++ b/btrfs_hook
@@ -140,6 +140,7 @@ btrfs_mount_handler () {
         ! umount ${BTRFS_DIR_WORK} &&
             btrfs_fatal "Unable to umount root subvolume" &&
             return 1
+        BTRFS_IS_MOUNTED=false
 
         # force reload kernel
         btrfs_info "Reloading kernel from [${BTRFS_BOOT_SUBVOL}]..."

--- a/btrfs_hook
+++ b/btrfs_hook
@@ -66,7 +66,7 @@ btrfs_mount_handler () {
     BTRFS_DIR_WORK=${work}
 
     # scan for multi device filesystems
-    btrfs device scan
+    btrfs device scan $device 2>&1 | grep -v "No medium found"
 
     # check if we already ran kexec
     : ${kexeced:=false}

--- a/btrfs_hook
+++ b/btrfs_hook
@@ -176,7 +176,7 @@ btrfs_mount_handler () {
                     kver_pointer="$(printf "%d\n" "0x${kver_pointer_hex}")"
                     #
                     # 0x0200 -> 512
-                    kver="$(dd if=${work}${BTRFS_BOOT_SUBVOL}${BTRFS_KERNEL} bs=1 skip=$((512+${kver_pointer})) count=128 2>/dev/null | sed 's/\x0.*/\n/')"
+                    kver="$(dd if=${work}${BTRFS_BOOT_SUBVOL}${BTRFS_KERNEL} bs=1 skip=$((512+${kver_pointer})) count=128 2>/dev/null | strings -n 10)"
                     echo "${kver}" | grep "$(uname -r)" | grep "$(uname -v)" 1>/dev/null
                     if [ ${?} -eq 0 ]; then
                         BTRFS_KVER_DIFFER=false

--- a/btrfs_hook
+++ b/btrfs_hook
@@ -155,21 +155,33 @@ btrfs_mount_handler () {
         btrfs_info "Booting from subvolume [${BTRFS_BOOT_SUBVOL}]..."
         btrfs subvolume set-default ${BTRFS_BOOT_SUBVOLID} ${work}
 
+        # if kernel rollback is enabled (so it is by default)
         if ${BTRFS_ROLLBACK_KERNEL}; then
-            # copy kernel to initramfs
-            cp "${work}${BTRFS_BOOT_SUBVOL}${BTRFS_KERNEL}" "/tmp/linux"
-            cp "${work}${BTRFS_BOOT_SUBVOL}${BTRFS_INITRD}" "/tmp/initrd"
 
-            # unmount btrfs root subvolume
-            ! umount ${BTRFS_DIR_WORK} &&
-                btrfs_fatal "Unable to umount root subvolume" &&
-                return 1
-            BTRFS_IS_MOUNTED=false
+            # test if a new kernel is present
+            if [ -f ${work}${BTRFS_BOOT_SUBVOL}${BTRFS_KERNEL} -a -f ${work}${BTRFS_BOOT_SUBVOL}${BTRFS_INITRD} ]; then
 
-            # force reload kernel
-            btrfs_info "Reloading kernel from [${BTRFS_BOOT_SUBVOL}]..."
-            kexec -f "/tmp/linux" --initrd="/tmp/initrd" --reuse-cmdline --append="kexeced=true"
-        else
+                # copy kernel to initramfs
+                cp "${work}${BTRFS_BOOT_SUBVOL}${BTRFS_KERNEL}" "/tmp/linux"
+                cp "${work}${BTRFS_BOOT_SUBVOL}${BTRFS_INITRD}" "/tmp/initrd"
+
+                # unmount btrfs root subvolume
+                ! umount ${BTRFS_DIR_WORK} &&
+                    btrfs_fatal "Unable to umount root subvolume" &&
+                    return 1
+                BTRFS_IS_MOUNTED=false
+
+                # force reload kernel
+                btrfs_info "Reloading kernel from [${BTRFS_BOOT_SUBVOL}]..."
+                kexec -f "/tmp/linux" --initrd="/tmp/initrd" --reuse-cmdline --append="kexeced=true"
+
+                # at this point the kernel reloads the initramfs and
+                # restarts init - no further code is executed
+            else
+                btrfs_warn "Unable to load new kernel from root subvolume"
+                btrfs_warn "Check your configuration in /etc/default/btrfs_advanced"
+            fi
+
             # unmount btrfs root subvolume
             ! umount ${BTRFS_DIR_WORK} &&
                 btrfs_fatal "Unable to umount root subvolume" &&

--- a/btrfs_hook
+++ b/btrfs_hook
@@ -60,6 +60,8 @@ BTRFS_DIR_ROLLBACK="${BTRFS_DIR_ROLLBACK%/}"
 : ${BTRFS_ROLLBACK_LIST_COUNT:=1}
 : ${BTRFS_KERNEL:="/boot/vmlinuz-linux"}
 : ${BTRFS_INITRD:="/boot/initramfs-linux.img"}
+: ${BTRFS_ENABLE_DEGRADED:=false}
+: ${BTRFS_ENABLE_DEGRADED_ROLLBACK:=false}
 
 btrfs_mount_handler () {
     local x i=1 work=${1%/}
@@ -68,15 +70,35 @@ btrfs_mount_handler () {
     # scan for multi device filesystems
     btrfs device scan $device 2>&1 | grep -v "No medium found"
 
+    # temporary mount btrfs root subvolume
+    if ! mount -t btrfs -o subvolid=0,rw ${root} ${work}; then
+
+        # try to mount in degraded mode
+        if ${BTRFS_ENABLE_DEGRADED}; then
+            if ! mount -t btrfs -o subvolid=0,rw,degraded ${root} ${work}; then
+                btrfs_fatal "Unable to mount root subvolume" &&
+                return 1
+            else
+                btrfs_warn "Mounted root subvolume in degraded mode"
+                sleep 3
+                rootflags="${rootflags},degraded"
+
+                # supress rollback choice in degraded mode
+                if ! ${BTRFS_ENABLE_DEGRADED_ROLLBACK}; then
+                    btrfs_info "Disabled rollback feature in degraded mode"
+                    kexeced=true
+                fi
+            fi
+        else
+            btrfs_fatal "Unable to mount root subvolume" &&
+            return 1
+        fi
+    fi
+    BTRFS_IS_MOUNTED=true
+
     # check if we already ran kexec
     : ${kexeced:=false}
     if ! ${kexeced}; then
-
-        # temporary mount btrfs root subvolume
-        ! mount -t btrfs -o subvolid=0,rw ${root} ${work} &&
-            btrfs_fatal "Unable to mount root subvolume" &&
-            return 1
-        BTRFS_IS_MOUNTED=true
 
         if ! [ -d ${work}${BTRFS_DIR_ACTIVE} ]; then
             if ! { btrfs_ask_volatile && btrfs_set_volatile; }; then

--- a/btrfs_hook
+++ b/btrfs_hook
@@ -304,7 +304,7 @@ btrfs_setup_rollback () {
 run_hook () {
 
     # root must be btrfs else silent return
-    if [ "$(blkid -s TYPE -o value ${root})" != "btrfs" -a "$(blkid -s TYPE -o value -lt ${root})" != "btrfs" ]; then
+    if [ "$(blkid -s TYPE -o value ${root} 2>/dev/null)" != "btrfs" -a "$(blkid -s TYPE -o value -lt ${root} 2>/dev/null)" != "btrfs" ]; then
         btrfs_warn "Root filesystem ${root} is not a BTRFS filesystem"
         return 0
     fi

--- a/btrfs_hook
+++ b/btrfs_hook
@@ -61,6 +61,8 @@ BTRFS_DIR_ROLLBACK="${BTRFS_DIR_ROLLBACK%/}"
 : ${BTRFS_ROLLBACK_KERNEL:=true}
 : ${BTRFS_KERNEL:="/boot/vmlinuz-linux"}
 : ${BTRFS_INITRD:="/boot/initramfs-linux.img"}
+: ${BTRFS_KVER_CHECK:=false}
+: ${BTRFS_KVER_DIFFER:=true}
 : ${BTRFS_ENABLE_DEGRADED:=false}
 : ${BTRFS_ENABLE_DEGRADED_ROLLBACK:=false}
 
@@ -161,22 +163,47 @@ btrfs_mount_handler () {
             # test if a new kernel is present
             if [ -f ${work}${BTRFS_BOOT_SUBVOL}${BTRFS_KERNEL} -a -f ${work}${BTRFS_BOOT_SUBVOL}${BTRFS_INITRD} ]; then
 
-                # copy kernel to initramfs
-                cp "${work}${BTRFS_BOOT_SUBVOL}${BTRFS_KERNEL}" "/tmp/linux"
-                cp "${work}${BTRFS_BOOT_SUBVOL}${BTRFS_INITRD}" "/tmp/initrd"
+                # compare running kernel's version against kernel image
+                if ${BTRFS_CHECK_KVER}; then
 
-                # unmount btrfs root subvolume
-                ! umount ${BTRFS_DIR_WORK} &&
-                    btrfs_fatal "Unable to umount root subvolume" &&
-                    return 1
-                BTRFS_IS_MOUNTED=false
+                    # extract kernel_version from header in kernel image
+                    # according to kernel documentation:
+                    # https://www.kernel.org/doc/Documentation/x86/boot.txt
+                    #
+                    # 0x020E -> 526
+                    kver_pointer_hex="$(dd if=${work}${BTRFS_BOOT_SUBVOL}${BTRFS_KERNEL} bs=1 skip=526 count=2 2>/dev/null | hexdump -e '"%x"')"
+                    # convert to decimal
+                    kver_pointer="$(printf "%d\n" "0x${kver_pointer_hex}")"
+                    #
+                    # 0x0200 -> 512
+                    kver="$(dd if=${work}${BTRFS_BOOT_SUBVOL}${BTRFS_KERNEL} bs=1 skip=$((512+${kver_pointer})) count=128 2>/dev/null | sed 's/\x0.*/\n/')"
+                    echo "${kver}" | grep "$(uname -r)" | grep "$(uname -v)" 1>/dev/null
+                    if [ ${?} -eq 0 ]; then
+                        BTRFS_KVER_DIFFER=false
+                    fi
+                fi
 
-                # force reload kernel
-                btrfs_info "Reloading kernel from [${BTRFS_BOOT_SUBVOL}]..."
-                kexec -f "/tmp/linux" --initrd="/tmp/initrd" --reuse-cmdline --append="kexeced=true"
+                # only load new kernel if versions differ
+                # if the above check failes they differ by default anyway
+                if ${BTRFS_KVER_DIFFER}; then
 
-                # at this point the kernel reloads the initramfs and
-                # restarts init - no further code is executed
+                    # copy kernel to initramfs
+                    cp "${work}${BTRFS_BOOT_SUBVOL}${BTRFS_KERNEL}" "/tmp/linux"
+                    cp "${work}${BTRFS_BOOT_SUBVOL}${BTRFS_INITRD}" "/tmp/initrd"
+
+                    # unmount btrfs root subvolume
+                    ! umount ${BTRFS_DIR_WORK} &&
+                        btrfs_fatal "Unable to umount root subvolume" &&
+                        return 1
+                    BTRFS_IS_MOUNTED=false
+
+                    # force reload kernel
+                    btrfs_info "Reloading kernel from [${BTRFS_BOOT_SUBVOL}]..."
+                    kexec -f "/tmp/linux" --initrd="/tmp/initrd" --reuse-cmdline --append="kexeced=true"
+
+                    # at this point the kernel reloads the initramfs and
+                    # restarts init - no further code is executed
+                fi
             else
                 btrfs_warn "Unable to load kernel from new root subvolume"
                 btrfs_warn "Check your config in /etc/default/btrfs_advanced"

--- a/mkinitcpio-btrfs.install
+++ b/mkinitcpio-btrfs.install
@@ -2,24 +2,26 @@ post_install() { post_upgrade "${@}"; }
 
 post_upgrade() {
 
-    echo
-
     { grep -qe '^HOOKS=.*btrfs[^_]' /etc/mkinitcpio.conf && cat <<'MSG'
->>> WARNING: detected active hook "btrfs" in /etc/mkinitcpio.conf; rename to
-    `btrfs_advanced` in /etc/mkinitcpio.conf else hook will *not* run
+
+==> WARNING: detected active hook "btrfs" in /etc/mkinitcpio.conf
+  -> You MUST rename it to "btrfs_advanced".
+     Else this hook will *not* run!
 MSG
 } || {
     [ -z "${2}" ] && ! grep -qe '^HOOKS=.*btrfs_advanced' /etc/mkinitcpio.conf && cat <<'MSG'
->>> Add hook to /etc/mkinitcpio.conf:
-    > HOOKS="[...] btrfs_advanced"
+
+==> Add hook to /etc/mkinitcpio.conf:
+  -> HOOKS="[...] btrfs_advanced"
 MSG
 }
 
     cat <<'MSG'
->>> Run mkinitcpio to update your initramfs image
+
+==> Run mkinitcpio to update your initramfs image
     # mkinitcpio -p linux
 
->>> ATTENTION: If you upgrade from version < 0.4 you need to adapt your
+==> ATTENTION: If you upgrade from version < 0.4 you need to adapt your
     bootloader configuration. From now on the hook uses btrfs's set-default
     feature to identify the subvolume to boot from. In result of that, the
     kernel is found under '/boot' instead of '/__active/boot'.
@@ -30,49 +32,41 @@ MSG
         _display_rollback_add_info
 
     cat <<'MSG'
->>> Have ideas for this hook? Share!
-    1) [BBS] http://bbs.archlinux.org/viewtopic.php?id=88195
-    2) [AUR] http://aur.archlinux.org/packages.php?ID=33376
+
+==> Have ideas for this hook? Share!
+  -> [GitHub] https://github.com/xtfxme/mkinitcpio-btrfs
+  -> [AUR]    https://aur.archlinux.org/packages/mkinitcpio-btrfs
 MSG
 
     echo
-
 }
 
 post_remove() {
 
     cat <<'MSG'
 
->>> Remove `btrfs_advanced` from HOOKS in /etc/mkinitcpio.conf
->>> Run mkinitcpio to update your initramfs image (remove hook)
+==> Remove "btrfs_advanced" from HOOKS in /etc/mkinitcpio.conf
+
+==> Run mkinitcpio to update your initramfs image (remove hook)
     # mkinitcpio -p linux
 MSG
 
-    [ $(vercmp ${1} 0.3) -ge 0 ] &&
-        _display_rollback_remove_info
-
     echo
-
 }
 
 _display_rollback_add_info() {
 
     cat <<'MSG'
->>> To ENABLE rollback support, EITHER:
-    1)  reboot and the hook will ask to do it for you
-    2)  run the following command RIGHT before rebooting:
-        # btrfs subvolume snapshot / /__active
-        ... changes between ^^^ and reboot are ignored
+
+==> To ENABLE rollback support, EITHER:
+  -> Reboot and the hook will ask to do it for you.
+  -> Or run the following command RIGHT before rebooting:
+     # btrfs subvolume snapshot / /__active
+     # btrfs subvolume list /
+     ID 256 gen 98 top level 5 path __active
+     # btrfs subvolume set-default 256 .
+     Changes between snapshot and reboot will be ignored!
 MSG
 
 }
 
-_display_rollback_remove_info() {
-
-    cat <<'MSG'
->>> If you ENABLED rollback support, YOU MUST ADD:
-    > [...] rootflags=subvol=__active
-    to your kernel boot line (grub*/syslinux/etc) else your system will not boot
-MSG
-
-}

--- a/mkinitcpio-btrfs.install
+++ b/mkinitcpio-btrfs.install
@@ -18,6 +18,8 @@ MSG
 
     cat <<'MSG'
 
+==> Have a look in /etc/default/btrfs_advanced to configure advanced options.
+
 ==> Run mkinitcpio to update your initramfs image
     # mkinitcpio -p linux
 


### PR DESCRIPTION
I pull this for discussion on 2916680cb700a3cb22cc8b89827e9918f0add035.

Recently I gave a lecture on btrfs filesystem at our local LUG. One upcoming concern in our discussion was about not being able to auto-mount degraded volumes. So if you have a server outside in a data-center using btrfs as root partition, you would not be able to boot after a power failure which can cause a disk to fail. So I wanted to come up with a solution for that.

I tried to implement this using `btrfs filesystem show`, but afterwards I thought it would be better to not rely on the output of btrfs commands, because they are still in development. Also there is no additional benefit using this method, beside preventing the first unsuccessful mount and its error output.

In my opinion we need to get the explicit approval from a user to mount degraded volumes automatically, because it may do additional harm to the filesystem. That's why I implemented it disabled by default.
